### PR TITLE
Improve Tracing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,10 +35,6 @@ lazy val `http4s-consul-middleware` = crossProject(JSPlatform, JVMPlatform)
   .settings(
     description := "http4s middleware to discover the host and port for an HTTP request using Consul",
     tpolecatScalacOptions += ScalacOptions.release("8"),
-    tlMimaPreviousVersions ++= {
-      if (scalaVersion.value.startsWith("2.")) Set("0.1.0")
-      else Set.empty
-    },
     libraryDependencies ++= {
       val http4sVersion = "0.23.27"
       val munitVersion = "1.0.0"

--- a/build.sbt
+++ b/build.sbt
@@ -54,8 +54,9 @@ lazy val `http4s-consul-middleware` = crossProject(JSPlatform, JVMPlatform)
         "org.typelevel" %%% "keypool" % "0.4.9",
         "org.typelevel" %%% "case-insensitive" % "1.4.0",
         "org.typelevel" %%% "cats-effect" % "3.5.4",
+        "org.typelevel" %%% "cats-mtl" % "1.4.0",
         "org.tpolecat" %%% "natchez-core" % "0.3.5",
-        "org.tpolecat" %%% "natchez-http4s" % "0.5.0",
+        "org.tpolecat" %%% "natchez-mtl" % "0.3.5",
         "org.typelevel" %%% "log4cats-noop" % log4catsVersion % Test,
         "org.http4s" %%% "http4s-ember-client" % http4sVersion % Test,
         "org.http4s" %%% "http4s-dsl" % http4sVersion % Test,
@@ -67,7 +68,6 @@ lazy val `http4s-consul-middleware` = crossProject(JSPlatform, JVMPlatform)
         compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
       )
       else Seq.empty)
-
     },
   )
   .jvmSettings(

--- a/core/js/src/test/scala/com/dwolla/consul/examples/ConsulMiddlewareAppPlatform.scala
+++ b/core/js/src/test/scala/com/dwolla/consul/examples/ConsulMiddlewareAppPlatform.scala
@@ -1,15 +1,16 @@
 package com.dwolla.consul.examples
 
 import cats.effect._
-import natchez.Trace
-import natchez.noop.NoopSpan
+import natchez.Span
+import natchez.mtl.natchezMtlTraceForLocal
+import natchez.noop.NoopEntrypoint
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.noop.NoOpFactory
 
-trait ConsulMiddlewareAppPlatform extends IOApp.Simple {
+trait ConsulMiddlewareAppPlatform extends IOApp.Simple with LocalTracing {
   private implicit val noOpFactory: LoggerFactory[IO] = NoOpFactory[IO]
 
-  override def run: IO[Unit] = Trace.ioTrace(NoopSpan[IO]()).flatMap { implicit trace =>
-    new ConsulMiddlewareApp[IO].run
+  override def run: IO[Unit] = IOLocal(Span.noop[IO]).map(catsMtlEffectLocalForIO(_)).flatMap { implicit L =>
+    new ConsulMiddlewareApp[IO](NoopEntrypoint[IO]()).run
   }
 }

--- a/core/js/src/test/scala/com/dwolla/consul/examples/ConsulServiceDiscoveryAlgAppPlatform.scala
+++ b/core/js/src/test/scala/com/dwolla/consul/examples/ConsulServiceDiscoveryAlgAppPlatform.scala
@@ -1,15 +1,16 @@
 package com.dwolla.consul.examples
 
 import cats.effect._
-import natchez.Trace
-import natchez.noop.NoopSpan
+import natchez.Span
+import natchez.mtl.natchezMtlTraceForLocal
+import natchez.noop.NoopEntrypoint
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.noop.NoOpFactory
 
-trait ConsulServiceDiscoveryAlgAppPlatform extends IOApp.Simple {
+trait ConsulServiceDiscoveryAlgAppPlatform extends IOApp.Simple with LocalTracing {
   private implicit val noOpFactory: LoggerFactory[IO] = NoOpFactory[IO]
 
-  override def run: IO[Unit] = Trace.ioTrace(NoopSpan[IO]()).flatMap { implicit trace =>
-    new ConsulServiceDiscoveryAlgApp[IO].run
+  override def run: IO[Unit] = IOLocal(Span.noop[IO]).map(catsMtlEffectLocalForIO(_)).flatMap { implicit L =>
+    new ConsulServiceDiscoveryAlgApp[IO](NoopEntrypoint[IO]()).run
   }
 }

--- a/core/shared/src/main/scala/com/dwolla/consul/ConsulServiceDiscoveryAlg.scala
+++ b/core/shared/src/main/scala/com/dwolla/consul/ConsulServiceDiscoveryAlg.scala
@@ -1,5 +1,6 @@
 package com.dwolla.consul
 
+import cats.data.OptionT
 import cats.effect.kernel.Resource.ExitCase
 import cats.effect.std.Random
 import cats.effect.syntax.all._
@@ -53,11 +54,47 @@ trait ConsulServiceDiscoveryAlg[F[_]] { self =>
 }
 
 object ConsulServiceDiscoveryAlg {
+  /**
+   * Constructs a new instance of `ConsulServiceDiscoveryAlg[F]`. Since an `EntryPoint[F]` is provided, background
+   * requests will be traced in their own traces.
+   *
+   * @param consulBaseUri the base URI of the Consul API to call to resolve service addresses
+   * @param longPollTimeout how long to hold an open connection to the Consul API, waiting for a state change to be reported
+   * @param client the http4s `Client[F]` used to make requests of the Consul API
+   * @param entryPoint an `EntryPoint[F]` used to create new root traces for background processes
+   * @param L a `Local[F, Span[F]]` instance used to change the `Span[F]` context for specific scopes
+   * @tparam F the effect in which to operate
+   * @return a new instance of `ConsulServiceDiscoveryAlg[F]`
+   */
   def apply[F[_] : Temporal : LoggerFactory : Random : Trace](consulBaseUri: Uri,
                                                               longPollTimeout: FiniteDuration,
                                                               client: Client[F],
                                                               entryPoint: EntryPoint[F])
                                                              (implicit L: Local[F, Span[F]]): F[ConsulServiceDiscoveryAlg[F]] =
+    make(consulBaseUri, longPollTimeout, client, entryPoint.some)
+
+  /**
+   * Constructs a new instance of `ConsulServiceDiscoveryAlg[F]`. Since no `EntryPoint[F]` is provided, background
+   * requests will not be traced.
+   *
+   * @param consulBaseUri the base URI of the Consul API to call to resolve service addresses
+   * @param longPollTimeout how long to hold an open connection to the Consul API, waiting for a state change to be reported
+   * @param client the http4s `Client[F]` used to make requests of the Consul API
+   * @param L a `Local[F, Span[F]]` instance used to change the `Span[F]` context for specific scopes
+   * @tparam F the effect in which to operate
+   * @return a new instance of `ConsulServiceDiscoveryAlg[F]`
+   */
+  def apply[F[_] : Temporal : LoggerFactory : Random : Trace](consulBaseUri: Uri,
+                                                              longPollTimeout: FiniteDuration,
+                                                              client: Client[F])
+                                                             (implicit L: Local[F, Span[F]]): F[ConsulServiceDiscoveryAlg[F]] =
+    make(consulBaseUri, longPollTimeout, client, None)
+
+  private def make[F[_] : Temporal : LoggerFactory : Random : Trace](consulBaseUri: Uri,
+                                                                     longPollTimeout: FiniteDuration,
+                                                                     client: Client[F],
+                                                                     entryPoint: Option[EntryPoint[F]])
+                                                                    (implicit L: Local[F, Span[F]]): F[ConsulServiceDiscoveryAlg[F]] =
     LoggerFactory[F]
       .create(LoggerName("com.dwolla.consul.ConsulServiceDiscoveryAlg"))
       .map { implicit l =>
@@ -141,6 +178,7 @@ object ConsulServiceDiscoveryAlg {
    * @param consulBase the base URI where the Consul API can be accessed, e.g. [[http://localhost:8500]]
    * @param longPollTimeout the maximum amount of time to wait before Consul should return a response
    * @param client the `org.http4s.client.Client[F]` used to interact with the Consul API. Should be configured not to timeout on blocking queries
+   * @param entryPoint an optional EntryPoint used to construct new traces for background requests. If none, a no-op span is used instead.
    * @return a `cats.effect.Resource` managing the background process and containing an effect to view the current set of available instances
    */
   private def continuallyUpdating[F[_] : Temporal : Logger](serviceName: ServiceName,
@@ -149,7 +187,7 @@ object ConsulServiceDiscoveryAlg {
                                                             consulBase: Uri,
                                                             longPollTimeout: FiniteDuration,
                                                             client: Client[F],
-                                                            entryPoint: EntryPoint[F],
+                                                            entryPoint: Option[EntryPoint[F]],
                                                            )
                                                            (implicit L: Local[F, Span[F]]): Resource[F, F[Vector[Uri.Authority]]] =
     Stream.unfoldEval(initialConsulIndex) { maybeIndex =>
@@ -172,17 +210,21 @@ object ConsulServiceDiscoveryAlg {
       .onFinalize(Logger[F].trace(s"👋 shutting down continuallyUpdating($serviceName, …)"))
       .map(_.get)
 
-  private def inNewLinkedRootSpan[F[_] : MonadCancelThrow, A](entryPoint: EntryPoint[F])
+  private def inNewLinkedRootSpan[F[_] : MonadCancelThrow, A](entryPoint: Option[EntryPoint[F]])
                                                              (fa: F[A])
                                                              (implicit L: Local[F, Span[F]]): F[A] =
-    natchez.mtl.natchezMtlTraceForLocal
-      .kernel
-      .map(Span.Options.Defaults.withLink)
-      .flatMap {
-        entryPoint
-          .root("com.dwolla.consul.ConsulServiceDiscoveryAlg.continuallyUpdating", _)
-          .use(Local[F, Span[F]].scope(fa))
+    OptionT.fromOption[Resource[F, *]](entryPoint)
+      .semiflatMap { ep =>
+        natchez.mtl.natchezMtlTraceForLocal
+          .kernel
+          .map(Span.Options.Defaults.withLink)
+          .toResource
+          .flatMap {
+            ep.root("com.dwolla.consul.ConsulServiceDiscoveryAlg.continuallyUpdating", _)
+          }
       }
+      .getOrElse(Span.noop)
+      .use(Local[F, Span[F]].scope(fa))
 
   private[consul] def serviceListUri(consulBase: Uri,
                                      serviceName: ServiceName,

--- a/core/shared/src/main/scala/com/dwolla/consul/ConsulServiceDiscoveryAlg.scala
+++ b/core/shared/src/main/scala/com/dwolla/consul/ConsulServiceDiscoveryAlg.scala
@@ -1,17 +1,18 @@
 package com.dwolla.consul
 
 import cats.effect.kernel.Resource.ExitCase
-import cats.{Monad, ~>}
 import cats.effect.std.Random
 import cats.effect.syntax.all._
 import cats.effect.{Trace => _, _}
+import cats.mtl.Local
 import cats.syntax.all._
+import cats.{Monad, ~>}
 import com.dwolla.consul.ThirdPartyTypeCodecs._
 import fs2.Stream
 import io.circe.optics.JsonPath.root
 import io.circe.{Decoder, Json}
 import monocle.Traversal
-import natchez.Trace
+import natchez.{EntryPoint, Span, Trace}
 import org.http4s.Method.GET
 import org.http4s._
 import org.http4s.circe.jsonOf
@@ -54,7 +55,9 @@ trait ConsulServiceDiscoveryAlg[F[_]] { self =>
 object ConsulServiceDiscoveryAlg {
   def apply[F[_] : Temporal : LoggerFactory : Random : Trace](consulBaseUri: Uri,
                                                               longPollTimeout: FiniteDuration,
-                                                              client: Client[F]): F[ConsulServiceDiscoveryAlg[F]] =
+                                                              client: Client[F],
+                                                              entryPoint: EntryPoint[F])
+                                                             (implicit L: Local[F, Span[F]]): F[ConsulServiceDiscoveryAlg[F]] =
     LoggerFactory[F]
       .create(LoggerName("com.dwolla.consul.ConsulServiceDiscoveryAlg"))
       .map { implicit l =>
@@ -63,7 +66,7 @@ object ConsulServiceDiscoveryAlg {
             lookup[F](serviceName, consulBaseUri, None, longPollTimeout, client)
               .toResource
               .flatMap { case (initialValue, initialConsulIndex) =>
-                continuallyUpdating(serviceName, initialValue, initialConsulIndex, consulBaseUri, longPollTimeout, client)
+                continuallyUpdating(serviceName, initialValue, initialConsulIndex, consulBaseUri, longPollTimeout, client, entryPoint)
               }
               .onFinalize(Logger[F].trace(s"👋 shutting down authoritiesForService($serviceName)"))
         }
@@ -145,24 +148,41 @@ object ConsulServiceDiscoveryAlg {
                                                             initialConsulIndex: Option[ConsulIndex],
                                                             consulBase: Uri,
                                                             longPollTimeout: FiniteDuration,
-                                                            client: Client[F]): Resource[F, F[Vector[Uri.Authority]]] =
+                                                            client: Client[F],
+                                                            entryPoint: EntryPoint[F],
+                                                           )
+                                                           (implicit L: Local[F, Span[F]]): Resource[F, F[Vector[Uri.Authority]]] =
     Stream.unfoldEval(initialConsulIndex) { maybeIndex =>
-      // since this is a background task, it doesn't make sense to attach it to the trace that initially started it
-      import natchez.Trace.Implicits.noop
+      inNewLinkedRootSpan(entryPoint) { // since this is a background task, it doesn't make sense
+        import natchez.mtl._            // to directly attach it to the trace that initially started it,
+                                        // but linking it to the new root span is helpful
 
-      lookup[F](serviceName, consulBase, maybeIndex, longPollTimeout, client)
-        .map(_.leftMap(_.some))                               // if we successfully got values, wrap them in Some so we can unNone later
-        .handleErrorWith {
-          // TODO maybe we should introduce some kind of escalating delay here?
-          Logger[F].warn(_)("🔥 An exception occurred getting service details from Consul; retrying")
-            .as((none[Vector[Uri.Authority]], maybeIndex))    // continue successfully, but emit None so the failure can be filtered out later
-        }
-        .map(_.some)                                          // this stream will unfold forever (well, until its Resource is finalized)
+        lookup[F](serviceName, consulBase, maybeIndex, longPollTimeout, client)
+          .map(_.leftMap(_.some)) // if we successfully got values, wrap them in Some so we can unNone later
+          .handleErrorWith {
+            // TODO maybe we should introduce some kind of escalating delay here?
+            Logger[F].warn(_)("🔥 An exception occurred getting service details from Consul; retrying")
+              .as((none[Vector[Uri.Authority]], maybeIndex)) // continue successfully, but emit None so the failure can be filtered out later
+          }
+          .map(_.some) // this stream will unfold forever (well, until its Resource is finalized)
+      }
     }
-      .unNone                                                 // errors returned by `lookup` are emitted as None, so filter them out
+      .unNone          // errors returned by `lookup` are emitted as None, so filter them out
       .holdResource(initialValue)
       .onFinalize(Logger[F].trace(s"👋 shutting down continuallyUpdating($serviceName, …)"))
       .map(_.get)
+
+  private def inNewLinkedRootSpan[F[_] : MonadCancelThrow, A](entryPoint: EntryPoint[F])
+                                                             (fa: F[A])
+                                                             (implicit L: Local[F, Span[F]]): F[A] =
+    natchez.mtl.natchezMtlTraceForLocal
+      .kernel
+      .map(Span.Options.Defaults.withLink)
+      .flatMap {
+        entryPoint
+          .root("com.dwolla.consul.ConsulServiceDiscoveryAlg.continuallyUpdating", _)
+          .use(Local[F, Span[F]].scope(fa))
+      }
 
   private[consul] def serviceListUri(consulBase: Uri,
                                      serviceName: ServiceName,
@@ -172,15 +192,6 @@ object ConsulServiceDiscoveryAlg {
     consulBase / "v1" / "health" / "service" / serviceName +? OnlyHealthyServices +?? index +?? index.as(WaitPeriod(longPollTimeout))
 
   private implicit def jsonEntityDecoder[F[_] : Concurrent, A: Decoder]: EntityDecoder[F, A] = jsonOf[F, A]
-
-  @deprecated("used traced version", "0.2.0")
-  def apply[F[_]](consulBaseUri: Uri,
-                  longPollTimeout: FiniteDuration,
-                  client: Client[F],
-                  F: Temporal[F],
-                  L: LoggerFactory[F],
-                  R: Random[F]): F[ConsulServiceDiscoveryAlg[F]] =
-    ConsulServiceDiscoveryAlg(consulBaseUri, longPollTimeout, client)(F, L, R, natchez.Trace.Implicits.noop(F))
 }
 
 abstract class AbstractConsulServiceDiscoveryAlg[F[_] : Random : Monad] extends ConsulServiceDiscoveryAlg[F] {

--- a/core/shared/src/main/scala/com/dwolla/consul/ConsulUriResolver.scala
+++ b/core/shared/src/main/scala/com/dwolla/consul/ConsulUriResolver.scala
@@ -56,9 +56,4 @@ object ConsulUriResolver {
             .flatTap(newUri => Logger[F].trace(s"  rewrote $source to $newUri"))
 
     }
-
-  @deprecated("used traced version", "0.2.0")
-  def apply[F[_]](backgroundResolver: ConsulServiceDiscoveryAlg[F], F: Async[F], L: LoggerFactory[F]): Resource[F, ConsulUriResolver[F]] =
-    ConsulUriResolver(backgroundResolver)(F, L, natchez.Trace.Implicits.noop(F))
-
 }

--- a/core/shared/src/main/scala/com/dwolla/consul/http4s/ConsulMiddleware.scala
+++ b/core/shared/src/main/scala/com/dwolla/consul/http4s/ConsulMiddleware.scala
@@ -40,13 +40,4 @@ object ConsulMiddleware {
           }
           .onFinalize(Logger[F].trace("👋 shutting down ConsulMiddleware"))
       }
-
-  @deprecated("used traced version", "0.2.0")
-  def apply[F[_]](consulServiceDiscoveryAlg: ConsulServiceDiscoveryAlg[F],
-                  client: Client[F],
-                  F: Async[F],
-                  L: LoggerFactory[F]): Resource[F, Client[F]] = {
-    ConsulMiddleware(consulServiceDiscoveryAlg)(client)(F, L, natchez.Trace.Implicits.noop(F))
-  }
-
 }

--- a/core/shared/src/test/scala/com/dwolla/consul/examples/ConsulServiceDiscoveryAlgApp.scala
+++ b/core/shared/src/test/scala/com/dwolla/consul/examples/ConsulServiceDiscoveryAlgApp.scala
@@ -3,10 +3,11 @@ package examples
 
 import cats.effect.{Trace => _, _}
 import cats.effect.std.Random
+import cats.mtl.Local
 import cats.syntax.all._
 import fs2.Stream
 import fs2.io.net.Network
-import natchez.Trace
+import natchez.{EntryPoint, Span, Trace}
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.syntax.all._
@@ -14,7 +15,8 @@ import org.typelevel.log4cats.{Logger, LoggerFactory}
 
 import scala.concurrent.duration._
 
-class ConsulServiceDiscoveryAlgApp[F[_] : Async : LoggerFactory : Trace : Network] extends Http4sClientDsl[F] {
+class ConsulServiceDiscoveryAlgApp[F[_] : Async : LoggerFactory : Trace : Network](entryPoint: EntryPoint[F])
+                                                                                  (implicit L: Local[F, Span[F]]) extends Http4sClientDsl[F] {
   private implicit def loggerR(implicit L: Logger[F]): Logger[Resource[F, *]] = Logger[F].mapK(Resource.liftK)
 
   private val serviceName = ServiceName("httpd")
@@ -26,7 +28,7 @@ class ConsulServiceDiscoveryAlgApp[F[_] : Async : LoggerFactory : Trace : Networ
           EmberClientBuilder
             .default[F]
             .build
-            .evalMap(ConsulServiceDiscoveryAlg(uri"http://localhost:8500", 1.minute, _))
+            .evalMap(ConsulServiceDiscoveryAlg(uri"http://localhost:8500", 1.minute, _, entryPoint))
         }
           .flatMap { alg =>
             Stream

--- a/core/shared/src/test/scala/com/dwolla/consul/examples/LocalTracing.scala
+++ b/core/shared/src/test/scala/com/dwolla/consul/examples/LocalTracing.scala
@@ -1,0 +1,33 @@
+package com.dwolla.consul.examples
+
+import cats.Applicative
+import cats.effect.{IO, IOLocal}
+import cats.mtl.Local
+
+trait LocalTracing {
+  /**
+   * Given an `IOLocal[E]`, provides a `Local[IO, E]`.
+   *
+   * Copied from [[https://github.com/armanbilge/oxidized/blob/412be9cd0a60b901fd5f9157ea48bda8632c5527/core/src/main/scala/oxidized/instances/io.scala#L34-L43 armanbilge/oxidized]]
+   * but hopefully this instance can be brought into cats-effect someday and
+   * removed here. See [[https://github.com/typelevel/cats-effect/issues/3385 typelevel/cats-effect#3385]]
+   * for more discussion.
+   *
+   * TODO remove if made more widely available upstream
+   *
+   * @param ioLocal the `IOLocal` that propagates the state of the `E` element
+   * @tparam E the type of state to propagate
+   * @return a `Local[IO, E]` backed by the given `IOLocal[E]`
+   */
+  implicit def catsMtlEffectLocalForIO[E](implicit ioLocal: IOLocal[E]): Local[IO, E] =
+    new Local[IO, E] {
+      override def local[A](fa: IO[A])(f: E => E): IO[A] =
+        ioLocal.get.flatMap { initial =>
+          ioLocal.set(f(initial)) >> fa.guarantee(ioLocal.set(initial))
+        }
+
+      override def applicative: Applicative[IO] = IO.asyncForIO
+
+      override def ask[E2 >: E]: IO[E2] = ioLocal.get
+    }
+}


### PR DESCRIPTION
The currently implementation attaches the background long polling requests to the trace of the first invocation of `authoritiesForService` for a given service. This keeps that trace alive much longer than it should. 

This PR fixes that by requiring an `EntryPoint[F]` and `Local[F, Span[F]]` on construction of the `ConsulServiceDiscoveryAlg[F]`, so that when a new background process is started, it can work in its own trace. The downside of this approach is that it requires breaking binary compatibility, but I think that's an acceptable tradeoff.