### PR TITLE
Remove circe-optics and add tests for authoritiesForService

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,12 +38,10 @@ lazy val `http4s-consul-middleware` = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= {
       val http4sVersion = "0.23.27"
       val munitVersion = "1.0.0"
-      val circeOpticsV = if (scalaBinaryVersion.value == "2.12") "0.14.1" else "0.15.0"
 
       Seq(
         "org.http4s" %%% "http4s-client" % http4sVersion,
         "org.http4s" %%% "http4s-circe" % http4sVersion,
-        "io.circe" %%% "circe-optics" % circeOpticsV,
         "io.circe" %%% "circe-literal" % "0.14.9",
         "io.monix" %%% "newtypes-core" % "0.2.3",
         "org.typelevel" %%% "log4cats-core" % log4catsVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ ThisBuild / startYear := Option(2022)
 tpolecatScalacOptions += ScalacOptions.release("8")
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
 ThisBuild / tlCiReleaseBranches := Seq("main")
-ThisBuild / tlBaseVersion := "0.4"
+ThisBuild / tlBaseVersion := "0.3"
 ThisBuild / tlSonatypeUseLegacyHost := true
 ThisBuild / mergifyStewardConfig ~= { _.map {
   _.withAuthor("dwolla-oss-scala-steward[bot]")
@@ -35,6 +35,7 @@ lazy val `http4s-consul-middleware` = crossProject(JSPlatform, JVMPlatform)
   .settings(
     description := "http4s middleware to discover the host and port for an HTTP request using Consul",
     tpolecatScalacOptions += ScalacOptions.release("8"),
+    tlVersionIntroduced := Map("3" -> "0.3.1", "2.12" -> "0.0.1", "2.13" -> "0.0.1"),
     libraryDependencies ++= {
       val http4sVersion = "0.23.27"
       val munitVersion = "1.0.0"
@@ -51,6 +52,7 @@ lazy val `http4s-consul-middleware` = crossProject(JSPlatform, JVMPlatform)
         "org.typelevel" %%% "cats-mtl" % "1.4.0",
         "org.tpolecat" %%% "natchez-core" % "0.3.5",
         "org.tpolecat" %%% "natchez-mtl" % "0.3.5",
+        "org.tpolecat" %%% "natchez-noop" % "0.3.5",
         "org.typelevel" %%% "log4cats-noop" % log4catsVersion % Test,
         "org.http4s" %%% "http4s-ember-client" % http4sVersion % Test,
         "org.http4s" %%% "http4s-dsl" % http4sVersion % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,7 @@ lazy val `http4s-consul-middleware` = crossProject(JSPlatform, JVMPlatform)
         "org.http4s" %%% "http4s-laws" % http4sVersion % Test,
         "org.scalameta" %%% "munit" % munitVersion % Test,
         "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test,
+        "com.comcast" %%% "ip4s-test-kit" % "3.6.0" % Test,
       ) ++ (if (scalaVersion.value.startsWith("2.")) Seq(
         compilerPlugin("org.typelevel" %% "kind-projector" % "0.13.3" cross CrossVersion.full),
         compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),

--- a/core/shared/src/main/scala/com/dwolla/consul/ConsulUriResolver.scala
+++ b/core/shared/src/main/scala/com/dwolla/consul/ConsulUriResolver.scala
@@ -5,6 +5,7 @@ import cats.effect.implicits.effectResourceOps
 import cats.syntax.all._
 import cats.~>
 import natchez.Trace
+import natchez.noop.NoopTrace
 import org.http4s.Uri.Host
 import org.http4s._
 import org.http4s.syntax.all._
@@ -56,4 +57,11 @@ object ConsulUriResolver {
             .flatTap(newUri => Logger[F].trace(s"  rewrote $source to $newUri"))
 
     }
+
+  @deprecated("maintained for binary compatibility: this version doesn't place background traces in the proper scope", "0.3.1")
+  def apply[F[_]](backgroundResolver: ConsulServiceDiscoveryAlg[F],
+                  F: Async[F],
+                  L: LoggerFactory[F]): Resource[F, ConsulUriResolver[F]] =
+    apply(backgroundResolver)(F, L, NoopTrace()(F))
+
 }

--- a/core/shared/src/main/scala/com/dwolla/consul/http4s/ConsulMiddleware.scala
+++ b/core/shared/src/main/scala/com/dwolla/consul/http4s/ConsulMiddleware.scala
@@ -4,6 +4,7 @@ import cats.effect.syntax.all._
 import cats.effect.{Trace => _, _}
 import com.dwolla.consul._
 import natchez.Trace
+import natchez.noop.NoopTrace
 import org.http4s._
 import org.http4s.client._
 import org.typelevel.log4cats._
@@ -40,4 +41,11 @@ object ConsulMiddleware {
           }
           .onFinalize(Logger[F].trace("👋 shutting down ConsulMiddleware"))
       }
+
+  @deprecated("maintained for binary compatibility: this version doesn't place background traces in the proper scope", "0.3.1")
+  def apply[F[_]](consulServiceDiscoveryAlg: ConsulServiceDiscoveryAlg[F],
+                  client: Client[F],
+                  F: Async[F],
+                  L: LoggerFactory[F]): Resource[F, Client[F]] =
+    apply(consulServiceDiscoveryAlg)(client)(F, L, NoopTrace()(F))
 }

--- a/core/shared/src/test/scala/cats/effect/std/ArbitraryRandom.scala
+++ b/core/shared/src/test/scala/cats/effect/std/ArbitraryRandom.scala
@@ -1,0 +1,17 @@
+package cats.effect.std
+
+import cats.syntax.all._
+import cats.effect.Sync
+import cats.effect.std.Random.ScalaRandom
+import org.scalacheck.{Arbitrary, Gen, Shrink}
+
+trait ArbitraryRandom {
+  def genRandom[F[_] : Sync]: Gen[Random[F]] =
+    Gen.long
+      .map(new scala.util.Random(_).pure[F])
+      .map(new ScalaRandom[F](_) {})
+
+  implicit def arbRandom[F[_] : Sync]: Arbitrary[Random[F]] = Arbitrary(genRandom[F])
+
+  implicit def shrinkRandom[F[_]]: Shrink[Random[F]] = Shrink.shrinkAny
+}

--- a/core/shared/src/test/scala/com/dwolla/consul/Arbitraries.scala
+++ b/core/shared/src/test/scala/com/dwolla/consul/Arbitraries.scala
@@ -6,7 +6,7 @@ trait ConsulArbitraries {
   val genServiceName: Gen[ServiceName] = Gen.identifier.map(ServiceName(_))
   implicit val arbServiceName: Arbitrary[ServiceName] = Arbitrary(genServiceName)
 
-  val genConsulIndex: Gen[ConsulIndex] = Gen.identifier.map(ConsulIndex(_))
+  val genConsulIndex: Gen[ConsulIndex] = Gen.posNum[Long].map(ConsulIndex(_))
   implicit val arbConsulIndex: Arbitrary[ConsulIndex] = Arbitrary(genConsulIndex)
 }
 

--- a/core/shared/src/test/scala/com/dwolla/consul/ConsulServiceDiscoveryAlgSpec.scala
+++ b/core/shared/src/test/scala/com/dwolla/consul/ConsulServiceDiscoveryAlgSpec.scala
@@ -120,7 +120,7 @@ class ConsulApi[F[_] : Temporal](services: Vector[ConsulApi.Service]) extends Ht
   object WaitPeriod extends OptionalQueryParamDecoderMatcher[com.dwolla.consul.WaitPeriod]("wait")
 
   def routes: HttpRoutes[F] = HttpRoutes.of {
-    case GET -> Root / "v1" / "health" / "service" / serviceName :? OnlyHealthyServices(_) :? ConsulIndex(idx) :? WaitPeriod(timeout) =>
+    case GET -> Root / "v1" / "health" / "service" / serviceName :? OnlyHealthyServices(true) :? ConsulIndex(idx) :? WaitPeriod(timeout) =>
       val json = services.filter {
         case ConsulApi.Service(ServiceName(`serviceName`), _, _, true) => true
         case _ => false

--- a/core/shared/src/test/scala/com/dwolla/consul/ConsulServiceDiscoveryAlgSpec.scala
+++ b/core/shared/src/test/scala/com/dwolla/consul/ConsulServiceDiscoveryAlgSpec.scala
@@ -1,15 +1,42 @@
 package com.dwolla.consul
 
+import cats.effect.std._
+import cats.effect.syntax.all._
+import cats.effect.{IO, IOLocal, Temporal}
 import cats.syntax.all._
+import com.comcast.ip4s.Arbitraries._
+import com.comcast.ip4s.{IpAddress, Port}
 import com.dwolla.consul.arbitraries._
-import munit.ScalaCheckSuite
-import org.http4s.Uri
+import com.dwolla.consul.examples.LocalTracing
+import io.circe.Encoder
+import io.circe.literal._
+import io.circe.syntax._
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import natchez.Span
+import natchez.mtl.natchezMtlTraceForLocal
+import org.http4s.Uri.Host
+import org.http4s._
+import org.http4s.circe._
+import org.http4s.client.Client
+import org.http4s.dsl.Http4sDsl
 import org.http4s.laws.discipline.arbitrary.http4sTestingArbitraryForUri
-import org.scalacheck.Prop
+import org.http4s.syntax.all._
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.effect.PropF
+import org.scalacheck._
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.noop.NoOpFactory
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
-class ConsulServiceDiscoveryAlgSpec extends ScalaCheckSuite {
+class ConsulServiceDiscoveryAlgSpec
+  extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with cats.effect.std.ArbitraryRandom
+    with LocalTracing {
+
+  private implicit val noopLoggerFactory: LoggerFactory[IO] = NoOpFactory[IO]
+
   test("Consul service lookup URI construction") {
     Prop.forAll { (consulBase: Uri,
                    serviceName: ServiceName,
@@ -31,4 +58,78 @@ class ConsulServiceDiscoveryAlgSpec extends ScalaCheckSuite {
       assertEquals(output, expected)
     }
   }
+
+  test("authoritiesForService returns the URIs for the service returned by Consul") {
+    PropF.forAllF { (services: Vector[ConsulApi.Service],
+                     randomInstance: Random[IO],
+                    ) =>
+      val http4sClient: Client[IO] = Client.fromHttpApp(new ConsulApi[IO](services).app)
+      implicit val random: Random[IO] = randomInstance
+
+      IOLocal(Span.noop[IO]).flatMap { implicit ioLocal =>
+        for {
+          alg <- ConsulServiceDiscoveryAlg(uri"/", 5.seconds, http4sClient)
+          serviceName <- Random[IO].shuffleVector(services).map(_.headOption.map(_.name).getOrElse(ServiceName("missing")))
+          output <- alg.authoritiesForService(serviceName).use(_.delayBy(10.millis)) // delay a bit to make sure the background request is also made
+          expected = services.collect {
+            case ConsulApi.Service(`serviceName`, host, port, true) =>
+              Uri.Authority(None, Host.fromIpAddress(host), port.value.some)
+          }
+        } yield {
+          assertEquals(output, expected)
+        }
+      }
+    }
+  }
+}
+
+object ConsulApi {
+  case class Service(name: ServiceName, address: IpAddress, port: Port, isHealthy: Boolean)
+
+  object Service {
+    val genService: Gen[Service] =
+      for {
+        serviceName <- arbitrary[ServiceName]
+        address <- arbitrary[IpAddress]
+        port <- arbitrary[Port]
+        healthy <- arbitrary[Boolean]
+      } yield Service(serviceName, address, port, healthy)
+
+    implicit val arbService: Arbitrary[Service] = Arbitrary(genService)
+
+    implicit val encoder: Encoder[Service] = a =>
+      json"""{
+          "Node": {},
+          "Service": {
+            "Service": ${a.name},
+            "Address": ${a.address.toString},
+            "Port": ${a.port.value}
+          },
+          "Checks": [
+            {
+              "Status": ${(if (a.isHealthy) "passing" else "critical"): String}
+            }
+          ]
+        }"""
+  }
+}
+
+class ConsulApi[F[_] : Temporal](services: Vector[ConsulApi.Service]) extends Http4sDsl[F] {
+  object OnlyHealthyServices extends FlagQueryParamMatcher("passing")
+  object ConsulIndex extends OptionalQueryParamDecoderMatcher[com.dwolla.consul.ConsulIndex]("index")
+  object WaitPeriod extends OptionalQueryParamDecoderMatcher[com.dwolla.consul.WaitPeriod]("wait")
+
+  def routes: HttpRoutes[F] = HttpRoutes.of {
+    case GET -> Root / "v1" / "health" / "service" / serviceName :? OnlyHealthyServices(_) :? ConsulIndex(idx) :? WaitPeriod(timeout) =>
+      val json = services.filter {
+        case ConsulApi.Service(ServiceName(`serviceName`), _, _, true) => true
+        case _ => false
+      }.asJson
+
+      val consulIndex = idx.getOrElse(com.dwolla.consul.ConsulIndex(1L))
+
+      timeout.map(_.value).foldLeft(Ok(json, consulIndex))(_.delayBy(_))
+  }
+
+  def app: HttpApp[F] = routes.orNotFound
 }

--- a/core/shared/src/test/scala/com/dwolla/consul/examples/LocalTracing.scala
+++ b/core/shared/src/test/scala/com/dwolla/consul/examples/LocalTracing.scala
@@ -4,7 +4,7 @@ import cats.Applicative
 import cats.effect.{IO, IOLocal}
 import cats.mtl.Local
 
-trait LocalTracing {
+private[consul] trait LocalTracing {
   /**
    * Given an `IOLocal[E]`, provides a `Local[IO, E]`.
    *
@@ -19,7 +19,7 @@ trait LocalTracing {
    * @tparam E the type of state to propagate
    * @return a `Local[IO, E]` backed by the given `IOLocal[E]`
    */
-  implicit def catsMtlEffectLocalForIO[E](implicit ioLocal: IOLocal[E]): Local[IO, E] =
+  private[consul] implicit def catsMtlEffectLocalForIO[E](implicit ioLocal: IOLocal[E]): Local[IO, E] =
     new Local[IO, E] {
       override def local[A](fa: IO[A])(f: E => E): IO[A] =
         ioLocal.get.flatMap { initial =>


### PR DESCRIPTION
Removing circe-optics removes several dependencies from the project, reducing its bincompat exposure.