### PR TITLE
Remove Trace[F] from method signatures where Local[F, Span[F]] is also present

### DIFF
--- a/core/js/src/test/scala/com/dwolla/consul/examples/ConsulServiceDiscoveryAlgAppPlatform.scala
+++ b/core/js/src/test/scala/com/dwolla/consul/examples/ConsulServiceDiscoveryAlgAppPlatform.scala
@@ -2,7 +2,6 @@ package com.dwolla.consul.examples
 
 import cats.effect._
 import natchez.Span
-import natchez.mtl.natchezMtlTraceForLocal
 import natchez.noop.NoopEntrypoint
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.noop.NoOpFactory

--- a/core/jvm/src/test/scala/com/dwolla/consul/examples/ConsulServiceDiscoveryAlgAppPlatform.scala
+++ b/core/jvm/src/test/scala/com/dwolla/consul/examples/ConsulServiceDiscoveryAlgAppPlatform.scala
@@ -1,11 +1,10 @@
 package com.dwolla.consul.examples
 
-import cats.effect.{Trace => _, _}
+import cats.effect._
 import cats.syntax.all._
 import io.jaegertracing.Configuration._
 import natchez._
 import natchez.jaeger._
-import natchez.mtl.natchezMtlTraceForLocal
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.slf4j.Slf4jFactory
 

--- a/core/shared/src/test/scala/com/dwolla/consul/ConsulServiceDiscoveryAlgSpec.scala
+++ b/core/shared/src/test/scala/com/dwolla/consul/ConsulServiceDiscoveryAlgSpec.scala
@@ -13,7 +13,6 @@ import io.circe.literal._
 import io.circe.syntax._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import natchez.Span
-import natchez.mtl.natchezMtlTraceForLocal
 import org.http4s.Uri.Host
 import org.http4s._
 import org.http4s.circe._

--- a/core/shared/src/test/scala/com/dwolla/consul/examples/ConsulMiddlewareApp.scala
+++ b/core/shared/src/test/scala/com/dwolla/consul/examples/ConsulMiddlewareApp.scala
@@ -56,8 +56,8 @@ object ConsulMiddlewareApp extends ConsulMiddlewareAppPlatform {
       .parMapN(ConsulMiddleware(_)(_))
       .flatten
 
-  private def consulServiceDiscoveryAlg[F[_] : Async : Random : LoggerFactory : Trace : Network](entryPoint: EntryPoint[F])
-                                                                                                (implicit L: Local[F, Span[F]]): Resource[F, ConsulServiceDiscoveryAlg[F]] =
+  private def consulServiceDiscoveryAlg[F[_] : Async : Random : LoggerFactory : Network](entryPoint: EntryPoint[F])
+                                                                                        (implicit L: Local[F, Span[F]]): Resource[F, ConsulServiceDiscoveryAlg[F]] =
     longPollClient[F].evalMap(ConsulServiceDiscoveryAlg(uri"http://localhost:8500", 1.minute, _, entryPoint))
 
   private def longPollClient[F[_] : Async : Network]: Resource[F, Client[F]] = clientWithTimeout(75.seconds)

--- a/core/shared/src/test/scala/com/dwolla/consul/examples/ConsulServiceDiscoveryAlgApp.scala
+++ b/core/shared/src/test/scala/com/dwolla/consul/examples/ConsulServiceDiscoveryAlgApp.scala
@@ -1,13 +1,13 @@
 package com.dwolla.consul
 package examples
 
-import cats.effect.{Trace => _, _}
+import cats.effect._
 import cats.effect.std.Random
 import cats.mtl.Local
 import cats.syntax.all._
 import fs2.Stream
 import fs2.io.net.Network
-import natchez.{EntryPoint, Span, Trace}
+import natchez.{EntryPoint, Span}
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.syntax.all._
@@ -15,8 +15,8 @@ import org.typelevel.log4cats.{Logger, LoggerFactory}
 
 import scala.concurrent.duration._
 
-class ConsulServiceDiscoveryAlgApp[F[_] : Async : LoggerFactory : Trace : Network](entryPoint: EntryPoint[F])
-                                                                                  (implicit L: Local[F, Span[F]]) extends Http4sClientDsl[F] {
+class ConsulServiceDiscoveryAlgApp[F[_] : Async : LoggerFactory : Network](entryPoint: EntryPoint[F])
+                                                                          (implicit L: Local[F, Span[F]]) extends Http4sClientDsl[F] {
   private implicit def loggerR(implicit L: Logger[F]): Logger[Resource[F, *]] = Logger[F].mapK(Resource.liftK)
 
   private val serviceName = ServiceName("httpd")


### PR DESCRIPTION
Theoretically, the `Trace[F]` should always be redundant, since it can be derived from `Local[F, Span[F]]` using `natchez.mtl.natchezMtlTraceForLocal`, and removing the `Trace[F]` reduces the bincompat surface as well as removing the possibility that unrelated `Trace[F]` and `Local[F, Span[F]]` instances will be passed.