### PR TITLE
relax capability constraints on ConsulUriResolver and ConsulMiddleware

### DIFF
--- a/core/shared/src/main/scala/com/dwolla/consul/http4s/ConsulMiddleware.scala
+++ b/core/shared/src/main/scala/com/dwolla/consul/http4s/ConsulMiddleware.scala
@@ -23,8 +23,8 @@ object ConsulMiddleware {
    * @param consulServiceDiscoveryAlg: the [[ConsulServiceDiscoveryAlg]] used to construct the background processes
    * @param client the `org.http4s.client.Client[F]` being wrapped, which will be used to make the eventual service requests
    */
-  def apply[F[_] : Async : LoggerFactory : Trace](consulServiceDiscoveryAlg: ConsulServiceDiscoveryAlg[F])
-                                                 (client: Client[F]): Resource[F, Client[F]] =
+  def apply[F[_] : Temporal : LoggerFactory : Trace](consulServiceDiscoveryAlg: ConsulServiceDiscoveryAlg[F])
+                                                    (client: Client[F]): Resource[F, Client[F]] =
     LoggerFactory[F]
       .create(LoggerName("com.dwolla.consul.http4s.ConsulMiddleware"))
       .toResource
@@ -48,4 +48,12 @@ object ConsulMiddleware {
                   F: Async[F],
                   L: LoggerFactory[F]): Resource[F, Client[F]] =
     apply(consulServiceDiscoveryAlg)(client)(F, L, NoopTrace()(F))
+
+  @deprecated("maintained for binary compatibility: this version requires a higher capability constraint than is actually required", "0.3.2")
+  def apply[F[_]](consulServiceDiscoveryAlg: ConsulServiceDiscoveryAlg[F],
+                  client: Client[F],
+                  F: Async[F],
+                  L: LoggerFactory[F],
+                  T: Trace[F]): Resource[F, Client[F]] =
+    apply(consulServiceDiscoveryAlg)(client)(F, L, T)
 }


### PR DESCRIPTION
Just some cleanup; these methods don't need the higher capability traits for their implementations so it's best practice not to require them.