### PR TITLE
change the semantics of ConsulServiceDiscoveryAlg.authorityForService so that it blocks when no instances are available

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,7 @@ lazy val `http4s-consul-middleware` = crossProject(JSPlatform, JVMPlatform)
     description := "http4s middleware to discover the host and port for an HTTP request using Consul",
     tpolecatScalacOptions += ScalacOptions.release("8"),
     tlVersionIntroduced := Map("3" -> "0.3.1", "2.12" -> "0.0.1", "2.13" -> "0.0.1"),
+    scalacOptions ++= List("-Vimplicits").filter(_ => scalaVersion.value.startsWith("2.13")),
     libraryDependencies ++= {
       Seq(
         "org.http4s" %%% "http4s-client" % http4sVersion,

--- a/smithy4s-tests/src/test/scala-2/com/dwolla/consul/smithy4s/ConsulMiddlewareSpecPlatform.scala
+++ b/smithy4s-tests/src/test/scala-2/com/dwolla/consul/smithy4s/ConsulMiddlewareSpecPlatform.scala
@@ -1,0 +1,8 @@
+package com.dwolla.consul.smithy4s
+
+import com.dwolla.test.HelloService
+import org.http4s.Uri
+
+trait ConsulMiddlewareSpecPlatform {
+  val serviceUri: Uri = UriFromService(HelloService)
+}

--- a/smithy4s-tests/src/test/scala-2/com/dwolla/consul/smithy4s/FakeConsuleUriResolverPlatform.scala
+++ b/smithy4s-tests/src/test/scala-2/com/dwolla/consul/smithy4s/FakeConsuleUriResolverPlatform.scala
@@ -1,0 +1,8 @@
+package com.dwolla.consul.smithy4s
+
+import com.dwolla.test.HelloService
+import org.http4s.Uri
+
+trait FakeConsulUriResolverPlatform {
+  protected val baseAuthority: Uri.Authority = UriAuthorityFromService(HelloService)
+}

--- a/smithy4s-tests/src/test/scala-3/com/dwolla/consul/smithy4s/ConsulMiddlewareSpecPlatform.scala
+++ b/smithy4s-tests/src/test/scala-3/com/dwolla/consul/smithy4s/ConsulMiddlewareSpecPlatform.scala
@@ -1,0 +1,9 @@
+package com.dwolla.consul.smithy4s
+
+import org.http4s.Uri
+import org.http4s.syntax.all.*
+
+trait ConsulMiddlewareSpecPlatform {
+  // TODO replace stub with macro-derived implementation once Scala 3 macro is available
+  val serviceUri: Uri = uri"consul://hello-world"
+}

--- a/smithy4s-tests/src/test/scala-3/com/dwolla/consul/smithy4s/FakeConsulUriResolverPlatform.scala
+++ b/smithy4s-tests/src/test/scala-3/com/dwolla/consul/smithy4s/FakeConsulUriResolverPlatform.scala
@@ -1,0 +1,8 @@
+package com.dwolla.consul.smithy4s
+
+import org.http4s.*
+
+trait FakeConsulUriResolverPlatform {
+  // TODO replace stub with macro-derived implementation once Scala 3 macro is available
+  protected val baseAuthority: Uri.Authority = Uri.Authority(host = Uri.RegName("hello-world"))
+}


### PR DESCRIPTION
Previously, if a user called the getter effect returned by `ConsulServiceDiscoveryAlg.authorityForService` when no instances are available, the implementation would raise an `IllegalArgumentException` due to not being able to select a random index between 0 (inclusive) and 0 (exclusive). 

After this change, the getter will semantically block, returning a value when one becomes available. If callers would like to maintain the existing behavior, they can add a timeout to the getter.