### PR TITLE
Use sonatypeCredentialHost instead of tlSonatypeUseLegacyHost

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ tpolecatScalacOptions += ScalacOptions.release("8")
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / tlBaseVersion := "0.3"
-ThisBuild / tlSonatypeUseLegacyHost := true
+ThisBuild / sonatypeCredentialHost := xerial.sbt.Sonatype.sonatypeLegacy
 ThisBuild / mergifyStewardConfig ~= { _.map {
   _.withAuthor("dwolla-oss-scala-steward[bot]")
     .withMergeMinors(true)


### PR DESCRIPTION
`tlSonatypeUseLegacyHost` is deprecated and the deprecation note says to use this instead.