### PR TITLE
Move Smithy spec files to separate module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p core/jvm/target core/js/target smithy4s/.js/target smithy4s/.jvm/target project/target
+        run: mkdir -p core/jvm/target consul-discoverable-smithy-spec/target core/js/target smithy4s/.js/target smithy4s/.jvm/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar core/jvm/target core/js/target smithy4s/.js/target smithy4s/.jvm/target project/target
+        run: tar cf targets.tar core/jvm/target consul-discoverable-smithy-spec/target core/js/target smithy4s/.js/target smithy4s/.jvm/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,6 +20,14 @@ pull_request_rules:
   - '#approved-reviews-by>=1'
   actions:
     merge: {}
+- name: Label consul-discoverable-smithy-spec PRs
+  conditions:
+  - files~=^consul-discoverable-smithy-spec/
+  actions:
+    label:
+      add:
+      - consul-discoverable-smithy-spec
+      remove: []
 - name: Label core PRs
   conditions:
   - files~=^core/

--- a/consul-discoverable-smithy-spec/src/main/resources/META-INF/smithy/ConsulMiddleware.smithy
+++ b/consul-discoverable-smithy-spec/src/main/resources/META-INF/smithy/ConsulMiddleware.smithy
@@ -2,8 +2,6 @@ $version: "2.0"
 
 namespace com.dwolla.consul.smithy
 
-use smithy4s.meta#typeclass
-
 string ServiceName
 
 @trait(selector: ":is(service)")

--- a/consul-discoverable-smithy-spec/src/main/resources/META-INF/smithy/manifest
+++ b/consul-discoverable-smithy-spec/src/main/resources/META-INF/smithy/manifest
@@ -1,0 +1,1 @@
+ConsulMiddleware.smithy


### PR DESCRIPTION
This will allow the Smithy specs to be consumed from Scala version-agnostic contexts.