### PR TITLE
add ConsulDiscoverable typeclass and Scala 2 macro implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -117,6 +117,7 @@ lazy val `smithy4s-consul-middleware` = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "org.http4s" %%% "http4s-client" % http4sVersion,
       "com.disneystreaming.smithy4s" %%% "smithy4s-core" % smithy4sVersion.value,
+      "org.typelevel" %% "scalac-compat-annotation" % "0.1.4",
     ),
   )
   .jsSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -142,6 +142,14 @@ lazy val `smithy4s-consul-middleware-tests` = crossProject(JSPlatform, JVMPlatfo
         "com.comcast" %%% "ip4s-test-kit" % "3.6.0" % Test,
       )
     },
+    libraryDependencies ++= {
+      (scalaBinaryVersion.value) match {
+        case "2.12" | "2.13" =>
+          Seq("org.scala-lang" % "scala-compiler" % scalaVersion.value % Test)
+        case _ =>
+          Nil
+      }
+    },
     Compile / smithy4sInputDirs := List(
       baseDirectory.value.getParentFile / "src" / "main" / "smithy",
     ),

--- a/smithy4s-tests/src/test/scala-2/com/dwolla/consul/smithy4s/ConsulDiscoverableSpecPerScalaVersion.scala
+++ b/smithy4s-tests/src/test/scala-2/com/dwolla/consul/smithy4s/ConsulDiscoverableSpecPerScalaVersion.scala
@@ -1,5 +1,6 @@
-package com.dwolla.consul.smithy4s
+package some_other_package
 
+import com.dwolla.consul.smithy4s._
 import com.dwolla.test.HelloService
 import munit.FunSuite
 import org.http4s.Uri

--- a/smithy4s-tests/src/test/scala-2/com/dwolla/consul/smithy4s/ConsulDiscoverableSpecPerScalaVersion.scala
+++ b/smithy4s-tests/src/test/scala-2/com/dwolla/consul/smithy4s/ConsulDiscoverableSpecPerScalaVersion.scala
@@ -1,0 +1,27 @@
+package com.dwolla.consul.smithy4s
+
+import com.dwolla.test.HelloService
+import munit.FunSuite
+import org.http4s.Uri
+import org.http4s.Uri.Host
+
+trait ConsulDiscoverableSpecPerScalaVersion { self: FunSuite =>
+  val serviceUri: Uri = UriFromService(HelloService)
+  private val serviceHost: Host = HostFromService(HelloService)
+  private val serviceUriAuthority: Uri.Authority = UriAuthorityFromService(HelloService)
+
+  test("ConsulDiscoverable typeclass macro constructs a working instance of the typeclass") {
+    assertEquals(ConsulDiscoverable[HelloService].host, serviceHost)
+    assertEquals(ConsulDiscoverable[HelloService].uriAuthority, serviceUriAuthority)
+    assertEquals(ConsulDiscoverable[HelloService].uri, serviceUri)
+  }
+
+  test("ConsulDiscoverable typeclass macro returns no instance when the type parameter isn't a Smithy Service") {
+    assertEquals(
+      compileErrors("""ConsulDiscoverable[NotASmithy4sService]"""),
+      """error: Instances are only available for Smithy4s Services annotated with @discoverable
+        |ConsulDiscoverable[NotASmithy4sService]
+        |                  ^""".stripMargin
+    )
+  }
+}

--- a/smithy4s-tests/src/test/scala-2/com/dwolla/consul/smithy4s/UriFromServiceSpec.scala
+++ b/smithy4s-tests/src/test/scala-2/com/dwolla/consul/smithy4s/UriFromServiceSpec.scala
@@ -29,7 +29,3 @@ class UriFromServiceSpec extends FunSuite {
     }
   }
 }
-
-trait NotASmithy4sService[F[_]]
-object NotASmithy4sService
-trait NotASmithy4sServiceAndHasNoCompanionObject[F[_]]

--- a/smithy4s-tests/src/test/scala-3/com/dwolla/consul/smithy4s/ConsulDiscoverableSpecPerScalaVersion.scala
+++ b/smithy4s-tests/src/test/scala-3/com/dwolla/consul/smithy4s/ConsulDiscoverableSpecPerScalaVersion.scala
@@ -1,0 +1,15 @@
+package com.dwolla.consul.smithy4s
+
+import munit._
+
+// TODO implement tests with macro-derived implementation once Scala 3 macro is available
+trait ConsulDiscoverableSpecPerScalaVersion { self: FunSuite =>
+  test("ConsulDiscoverable typeclass macro returns no instance when the type parameter isn't a Smithy Service") {
+    assertEquals(
+      compileErrors("""ConsulDiscoverable[NotASmithy4sService]"""),
+      """error: Instances are only available for Smithy4s Services annotated with @discoverable
+        |ConsulDiscoverable[NotASmithy4sService]
+        |                                      ^""".stripMargin
+    )
+  }
+}

--- a/smithy4s-tests/src/test/scala-3/com/dwolla/consul/smithy4s/ConsulDiscoverableSpecPerScalaVersion.scala
+++ b/smithy4s-tests/src/test/scala-3/com/dwolla/consul/smithy4s/ConsulDiscoverableSpecPerScalaVersion.scala
@@ -1,4 +1,4 @@
-package com.dwolla.consul.smithy4s
+package some_other_package
 
 import munit._
 
@@ -6,7 +6,7 @@ import munit._
 trait ConsulDiscoverableSpecPerScalaVersion { self: FunSuite =>
   test("ConsulDiscoverable typeclass macro returns no instance when the type parameter isn't a Smithy Service") {
     assertEquals(
-      compileErrors("""ConsulDiscoverable[NotASmithy4sService]"""),
+      compileErrors("import com.dwolla.consul.smithy4s._\nConsulDiscoverable[NotASmithy4sService]"),
       """error: Instances are only available for Smithy4s Services annotated with @discoverable
         |ConsulDiscoverable[NotASmithy4sService]
         |                                      ^""".stripMargin

--- a/smithy4s-tests/src/test/scala/com/dwolla/consul/smithy4s/ConsulDiscoverableSpec.scala
+++ b/smithy4s-tests/src/test/scala/com/dwolla/consul/smithy4s/ConsulDiscoverableSpec.scala
@@ -1,4 +1,4 @@
-package com.dwolla.consul.smithy4s
+package some_other_package
 
 import munit._
 

--- a/smithy4s-tests/src/test/scala/com/dwolla/consul/smithy4s/ConsulDiscoverableSpec.scala
+++ b/smithy4s-tests/src/test/scala/com/dwolla/consul/smithy4s/ConsulDiscoverableSpec.scala
@@ -1,0 +1,7 @@
+package com.dwolla.consul.smithy4s
+
+import munit._
+
+class ConsulDiscoverableSpec
+  extends FunSuite
+    with ConsulDiscoverableSpecPerScalaVersion

--- a/smithy4s-tests/src/test/scala/com/dwolla/consul/smithy4s/NotSmithyServiceStubs.scala
+++ b/smithy4s-tests/src/test/scala/com/dwolla/consul/smithy4s/NotSmithyServiceStubs.scala
@@ -1,0 +1,6 @@
+package com.dwolla.consul.smithy4s
+
+trait NotASmithy4sService[F[_]]
+object NotASmithy4sService
+
+trait NotASmithy4sServiceAndHasNoCompanionObject[F[_]]

--- a/smithy4s/src/main/scala-2/com/dwolla/consul/smithy4s/ConsulDiscoverablePlatform.scala
+++ b/smithy4s/src/main/scala-2/com/dwolla/consul/smithy4s/ConsulDiscoverablePlatform.scala
@@ -1,0 +1,66 @@
+package com.dwolla.consul.smithy4s
+
+import cats.syntax.all._
+import com.dwolla.consul.smithy._
+import org.http4s.Uri.Host
+import smithy4s.Hints
+
+import scala.reflect.macros.whitebox
+import scala.util.Try
+
+trait ConsulDiscoverablePlatform {
+  implicit def derivedInstance[Alg[_[_]]]: ConsulDiscoverable[Alg] =
+    macro ConsulDiscoverableMacros.makeInstance[Alg]
+}
+
+object ConsulDiscoverableMacros {
+  def makeInstance[Alg[_[_]]](c: whitebox.Context): c.Expr[ConsulDiscoverable[Alg]] = {
+    import c.universe.{Try => _, _}
+
+    def findHintsInTree(tpe: Tree): Either[String, Hints] =
+      Try {
+        tpe.collect {
+            case x: TypTree =>
+              c.eval(c.Expr[Hints](q"${x.symbol.companion}.hints"))
+          }
+          .headOption
+          .toRight(s"could not find hints for $tpe")
+      }
+        .toEither
+        .leftMap(_.toString ++ s" (is $tpe a Smithy4s Service?)")
+        .flatten
+
+    def getDiscoverableFromHints(tpe: Tree): Hints => Either[String, Discoverable] =
+      _.get(Discoverable.tagInstance)
+        .toRight(s"could not find Discoverable hint for $tpe")
+
+    val getHostFromDiscoverable: PartialFunction[Discoverable, Either[String, Host]] = {
+      case Discoverable(ServiceName(serviceName)) =>
+        Host.fromString(serviceName)
+          .leftMap(_.message)
+    }
+
+    def hostToConsulDiscoverableExpr(tpe: Tree): Host => c.Expr[ConsulDiscoverable[Alg]] = host =>
+      c.Expr[ConsulDiscoverable[Alg]](
+        q"""
+          new _root_.com.dwolla.consul.smithy4s.ConsulDiscoverable[$tpe] {
+            override def host: _root_.org.http4s.Uri.Host = _root_.org.http4s.Uri.Host.unsafeFromString(${host.value})
+            override def uriAuthority: _root_.org.http4s.Uri.Authority = _root_.org.http4s.Uri.Authority(host = host)
+            override def uri: _root_.org.http4s.Uri = _root_.org.http4s.Uri(scheme = _root_.scala.Option(_root_.com.dwolla.consul.smithy4s.DiscoveryMacros.consulScheme), authority = _root_.scala.Option(uriAuthority))
+          }
+        """)
+
+    c.macroApplication match {
+      case TypeApply(_, List(tpe)) if tpe.symbol.companion != NoSymbol =>
+        val maybeExpr = findHintsInTree(tpe)
+          .flatMap(getDiscoverableFromHints(tpe))
+          .flatMap(getHostFromDiscoverable)
+          .map(hostToConsulDiscoverableExpr(tpe))
+
+        maybeExpr.fold(c.abort(c.enclosingPosition, _), identity)
+      case TypeApply(_, List(tpe)) if tpe.symbol.companion == NoSymbol =>
+        c.abort(c.enclosingPosition, s"$tpe is not a Smithy4s Service")
+      case other => c.abort(c.enclosingPosition, s"found $other, which is not a Smithy4s Service")
+    }
+  }
+}

--- a/smithy4s/src/main/scala-2/com/dwolla/consul/smithy4s/UriFromService.scala
+++ b/smithy4s/src/main/scala-2/com/dwolla/consul/smithy4s/UriFromService.scala
@@ -10,7 +10,7 @@ import org.http4s.syntax.all._
 import scala.reflect.macros.blackbox
 
 object DiscoveryMacros {
-  private val consulScheme: Scheme = scheme"consul"
+  val consulScheme: Scheme = scheme"consul"
 
   def makeUri[Alg[_[_, _, _, _, _]]](c: blackbox.Context)
                                     (service: c.Expr[smithy4s.Service[Alg]]): c.Expr[Uri] = {

--- a/smithy4s/src/main/scala-2/com/dwolla/consul/smithy4s/UriFromService.scala
+++ b/smithy4s/src/main/scala-2/com/dwolla/consul/smithy4s/UriFromService.scala
@@ -10,7 +10,7 @@ import org.http4s.syntax.all._
 import scala.reflect.macros.blackbox
 
 object DiscoveryMacros {
-  val consulScheme: Scheme = scheme"consul"
+  private[smithy4s] val consulScheme: Scheme = scheme"consul"
 
   def makeUri[Alg[_[_, _, _, _, _]]](c: blackbox.Context)
                                     (service: c.Expr[smithy4s.Service[Alg]]): c.Expr[Uri] = {

--- a/smithy4s/src/main/scala-3/com/dwolla/consul/smithy4s/ConsulDiscoverablePlatform.scala
+++ b/smithy4s/src/main/scala-3/com/dwolla/consul/smithy4s/ConsulDiscoverablePlatform.scala
@@ -1,0 +1,3 @@
+package com.dwolla.consul.smithy4s
+
+trait ConsulDiscoverablePlatform

--- a/smithy4s/src/main/scala/com/dwolla/consul/smithy4s/ConsulDiscoverable.scala
+++ b/smithy4s/src/main/scala/com/dwolla/consul/smithy4s/ConsulDiscoverable.scala
@@ -1,0 +1,17 @@
+package com.dwolla.consul.smithy4s
+
+import org.http4s.Uri
+import org.http4s.Uri.Host
+
+import scala.annotation.implicitNotFound
+
+@implicitNotFound("Instances are only available for Smithy4s Services annotated with @discoverable")
+trait ConsulDiscoverable[Alg[_[_]]] {
+  def host: Host
+  def uriAuthority: Uri.Authority
+  def uri: Uri
+}
+
+object ConsulDiscoverable extends ConsulDiscoverablePlatform {
+  def apply[Alg[_[_]] : ConsulDiscoverable]: ConsulDiscoverable[Alg] = implicitly
+}


### PR DESCRIPTION
Adding the `ConsulDiscoverable[Alg]` typeclass allows the macro-derived `Uri`, `Uri.Authority`, and `Host` values to be used with generic service types, e.g. in functions where the service is passed in and not a literal value.

I ran into this when trying to extract out some common code initializing Smithy4s clients from one of our internal codebases, so this should open up that possibility.